### PR TITLE
Slove the bug when salting peaks overlap

### DIFF
--- a/axidence/plugins/salting/event_fields.py
+++ b/axidence/plugins/salting/event_fields.py
@@ -1,4 +1,5 @@
 from typing import Tuple
+import numpy as np
 import strax
 from strax import Plugin
 from straxen import EventShadow, EventAmbience, EventNearestTriggering, EventSEDensity
@@ -7,11 +8,15 @@ from ...utils import merge_salted_real
 
 
 class EventFieldsSalted(Plugin):
+    __version__ = "0.1.0"
     child_plugin = True
 
     def compute(self, events_salted, peaks_salted, peaks):
         _peaks = merge_salted_real(peaks_salted, peaks, peaks.dtype)
-        return super().compute(events_salted, _peaks)
+        _, index, counts = np.unique(events_salted["time"], return_index=True, return_counts=True)
+        _result = super().compute(events_salted[index], _peaks)
+        result = np.repeat(_result, counts)
+        return result
 
 
 class EventShadowSalted(EventFieldsSalted, EventShadow):


### PR DESCRIPTION
When the environment is messy, the event can overlap with multiple salting peaks. Then we will see errors like:
```
  File "/home/xudc/straxen/straxen/plugins/events/event_basics.py", line 242, in fill_events
    raise ValueError(f"No peaks within event?\n{events[event_i]}")
ValueError: No peaks within event?
(27361, 1632306160955726312, 1632306161173099400, 27361, False)
```

This is because `strax._fully_contained_in`(which is used by `strax.split_by_containment` in `EventBasics`) will only return the first container of things. So `strax.split_by_containment` will return zero peaks in the event even if the peaks belong to the event, when events are duplicated.