### PR TITLE
Fix bug when triggering peak in an event is not from the salting peaks

### DIFF
--- a/axidence/plugins/cuts/cuts_event_building.py
+++ b/axidence/plugins/cuts/cuts_event_building.py
@@ -9,7 +9,7 @@ class MainS1Trigger(CutPlugin):
     cut_description = "Whether the salting S1 can be the main S2"
 
     def cut_by(self, events):
-        mask = events["s1_salt_number"] >= 0
+        mask = events["s1_salt_number"] == events["salt_number"]
         return mask
 
 
@@ -21,7 +21,7 @@ class MainS2Trigger(CutPlugin):
     cut_description = "Whether the salting S2 can be the main S2"
 
     def cut_by(self, events):
-        mask = events["s2_salt_number"] >= 0
+        mask = events["s2_salt_number"] == events["salt_number"]
         return mask
 
 

--- a/axidence/plugins/cuts/cuts_event_building.py
+++ b/axidence/plugins/cuts/cuts_event_building.py
@@ -2,7 +2,7 @@ from strax import CutPlugin, CutList
 
 
 class MainS1Trigger(CutPlugin):
-    __version__ = "0.0.0"
+    __version__ = "0.1.0"
     depends_on = "event_basics"
     provides = "cut_main_s1_trigger"
     cut_name = "cut_main_s1_trigger"
@@ -14,7 +14,7 @@ class MainS1Trigger(CutPlugin):
 
 
 class MainS2Trigger(CutPlugin):
-    __version__ = "0.0.0"
+    __version__ = "0.1.0"
     depends_on = "event_basics"
     provides = "cut_main_s2_trigger"
     cut_name = "cut_main_s2_trigger"


### PR DESCRIPTION
Following https://github.com/XENONnT/axidence/pull/73

In some very rare cases, the events will overlap with multiple salting peaks. So the triggering peak in an event might not be from the salting peaks but from other salting peaks. In these cases, the salting peaks are not triggering events, but their`s1_salting_number` or `s2_salting_number` can be not -1, but we need to remove them from the definition of "triggering".