### PR TITLE
`run_meta` depends on `peak_basics`

### DIFF
--- a/axidence/plugins/meta/run_meta.py
+++ b/axidence/plugins/meta/run_meta.py
@@ -7,7 +7,7 @@ class RunMeta(ExhaustPlugin):
     """Plugin that provides run metadata."""
 
     __version__ = "0.0.0"
-    depends_on = "event_basics"
+    depends_on = "peak_basics"
     provides = "run_meta"
     data_kind = "run_meta"
     save_when = strax.SaveWhen.EXPLICIT


### PR DESCRIPTION
Sometimes we want to play with event building, so `event_basics` might change rapidly.